### PR TITLE
Attempt to Implement Transformers like Mirror

### DIFF
--- a/udp_receiver/CMakeLists.txt
+++ b/udp_receiver/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
         MatrixDriver.h
         RowEncoding.cpp
         RowEncoding.h
-        Interleaving.cpp Interleaving.h)
+        Interleaving.cpp Interleaving.h
+	Transforming.cpp Transforming.h)
 
 target_link_libraries(udp_receiver -pthread)

--- a/udp_receiver/Interleaving.cpp
+++ b/udp_receiver/Interleaving.cpp
@@ -77,5 +77,5 @@ void Interleavers::dimZ16AB(unsigned &width, unsigned &height) {
 // Z-striped 2-bit address 8-pixel stripe
 void Interleavers::dimZ08AB(unsigned &width, unsigned &height) {
     width /= 2;
-//    height *= 2;
+    height *= 2;
 }

--- a/udp_receiver/Interleaving.cpp
+++ b/udp_receiver/Interleaving.cpp
@@ -77,5 +77,5 @@ void Interleavers::dimZ16AB(unsigned &width, unsigned &height) {
 // Z-striped 2-bit address 8-pixel stripe
 void Interleavers::dimZ08AB(unsigned &width, unsigned &height) {
     width /= 2;
-    height *= 2;
+//    height *= 2;
 }

--- a/udp_receiver/MatrixDriver.cpp
+++ b/udp_receiver/MatrixDriver.cpp
@@ -342,9 +342,9 @@ void MatrixDriver::setPixel(unsigned x, unsigned y, uint8_t r, uint8_t g, uint8_
     // apply interleaving
     (*interleaver)(x, y);
 
-   unsigned int ab = matrixWidth;
-    unsigned int bc = matrixHeight;
-    (*transformer)(x, y, ab, bc );
+   unsigned int mWidth = matrixWidth;
+    unsigned int mHeight = matrixHeight;
+    (*transformer)(x, y, mWidth, mHeight);
 
     // verify coordinate bounds
     if(x >= matrixWidth || y >= matrixHeight) return;

--- a/udp_receiver/MatrixDriver.h
+++ b/udp_receiver/MatrixDriver.h
@@ -35,7 +35,14 @@ public:
         Z08AB,              // Z-striped: 2-bit address, 8-pixel strips
     };
 
-    static MatrixDriver * createInstance(unsigned pwmBits, RowFormat rowFormat, Interleaving interleaving = NO_INTERLEAVING);
+    enum Transforming {
+        NO_TRANSFORMING,    // normal pixel mapping
+        MIRRORH,            // mirror transfor,er, horizontal
+        MIRRORV,            // mirror transfor,er, horizontal
+        ROTATE,             // rotation transformer
+    };
+
+    static MatrixDriver * createInstance(unsigned pwmBits, RowFormat rowFormat, Interleaving interleaving = NO_INTERLEAVING, Transforming transforming = NO_TRANSFORMING);
     ~MatrixDriver() override;
 
     void flipBuffer();
@@ -59,6 +66,7 @@ public:
 
 private:
     typedef void (*Interleaver) (unsigned &x, unsigned &y);
+    typedef void (*Transformer) (unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight);
 
     MatrixDriver(
             unsigned scanRowCnt,
@@ -66,12 +74,14 @@ private:
             const unsigned *mapPwmBit,
             size_t rowBlock,
             size_t pwmBlock,
-            Interleaving interleaving
+            Interleaving interleaving,
+	    Transforming transforming
     );
 
     const unsigned matrixWidth, matrixHeight, scanRowCnt, pwmRows, *mapPwmBit;
     const size_t rowBlock, pwmBlock;
     const Interleaver interleaver;
+    const Transformer transformer;
     PixelMapping *pixelMapping;
     unsigned rasterWidth, rasterHeight, canvasWidth, canvasHeight;
     bool isRunning;

--- a/udp_receiver/Transforming.cpp
+++ b/udp_receiver/Transforming.cpp
@@ -20,11 +20,11 @@ void Transformers::NoTransforming(unsigned int &x, unsigned int &y, unsigned &ma
 // horizontal mirror transformer
 void Transformers::MIRRORH(unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight) {
 	x = matrixWidth - 1 - x;
-	y = y ;
 }
 
 // vertical mirror transformer
 void Transformers::MIRRORV(unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight) {
+        y = matrixHeight - 1 - y;
 }
 
 // rotational transformer

--- a/udp_receiver/Transforming.cpp
+++ b/udp_receiver/Transforming.cpp
@@ -1,0 +1,32 @@
+//
+// Created by arahasya on 6/21/20.
+//
+
+#include "Transforming.h"
+
+// array of all transforming functions in order of MatrixDriver enum
+Transformers::Transformer Transformers::transformer[4] = {
+        Transformers::NoTransforming,
+	Transformers::MIRRORH,
+	Transformers::MIRRORV,
+	Transformers::ROTATE
+};
+
+// no transforming does nothing
+void Transformers::NoTransforming(unsigned int &x, unsigned int &y, unsigned &matrixWidth, unsigned &matrixHeight) {
+
+}
+
+// horizontal mirror transformer
+void Transformers::MIRRORH(unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight) {
+	x = matrixWidth - 1 - x;
+	y = y ;
+}
+
+// vertical mirror transformer
+void Transformers::MIRRORV(unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight) {
+}
+
+// rotational transformer
+void Transformers::ROTATE(unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight) {
+}

--- a/udp_receiver/Transforming.h
+++ b/udp_receiver/Transforming.h
@@ -1,0 +1,21 @@
+//
+// Created by arahasya on 6/21/20.
+//
+
+#ifndef UDP_RECEIVER_TRANSFORMING_H
+#define UDP_RECEIVER_TRANSFORMING_H
+
+namespace Transformers {
+    typedef void (*Transformer) (unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight);
+
+    // array of all transforming functions in order of MatrixDriver enum
+    extern Transformer transformer[];
+
+    // functions for transformer panel coordinate translation
+    void NoTransforming(unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight);
+    void MIRRORH(unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight);
+    void MIRRORV(unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight);
+    void ROTATE(unsigned &x, unsigned &y, unsigned &matrixWidth, unsigned &matrixHeight);
+}
+
+#endif //UDP_RECEIVER_TRANSFORMING_H

--- a/udp_receiver/main.cpp
+++ b/udp_receiver/main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char **argv) {
 
     // configure rgb matrix panel driver
     MatrixDriver::initGpio(MatrixDriver::gpio_rpi3);
-    matrix = MatrixDriver::createInstance(PWM_BITS, MatrixDriver::HUB75AB, MatrixDriver::Z08AB, MatrixDriver::MIRRORV);
+    matrix = MatrixDriver::createInstance(PWM_BITS, MatrixDriver::HUB75AB, MatrixDriver::Z08AB, MatrixDriver::MIRRORH);
     createPwmLutLinear(PWM_BITS, brightness, matrix->getPwmMapping());
     log("instantiated matrix driver");
     log("matrix canvas is %d x %d", matrix->getWidth(), matrix->getHeight());

--- a/udp_receiver/main.cpp
+++ b/udp_receiver/main.cpp
@@ -109,14 +109,14 @@ int main(int argc, char **argv) {
 
     // configure rgb matrix panel driver
     MatrixDriver::initGpio(MatrixDriver::gpio_rpi3);
-    matrix = MatrixDriver::createInstance(PWM_BITS, MatrixDriver::HUB75AB, MatrixDriver::Z08AB);
+    matrix = MatrixDriver::createInstance(PWM_BITS, MatrixDriver::HUB75AB, MatrixDriver::Z08AB, MatrixDriver::MIRRORH);
     createPwmLutLinear(PWM_BITS, brightness, matrix->getPwmMapping());
     log("instantiated matrix driver");
     log("matrix canvas is %d x %d", matrix->getWidth(), matrix->getHeight());
 
     // set panel remapping
-    //PixelMapDoubleWide pixMap(*matrix);
-    //matrix->setPixelMapping(&pixMap);
+  //  PixelMapDoubleWide pixMap(*matrix);
+   // matrix->setPixelMapping(&pixMap);
     log("matrix canvas remapped as %d x %d", matrix->getCanvasWidth(), matrix->getCanvasHeight());
 
     // initialize packet buffer
@@ -269,7 +269,8 @@ long microtime() {
 void displayAddress(uint32_t addr) {
     // display ethernet address
     matrix->clearFrame();
-    auto x = matrix->getWidth() - 90;
+  //  auto x = matrix->getWidth() - 90;
+   auto x = 0;
     for(int i = 0; i < 4; i++) {
         auto octet = (addr >> ((3u - i) * 8u)) & 0xffu;
         unsigned pow = 100;
@@ -317,7 +318,6 @@ frame_packet* getPacket(unsigned frame, unsigned subframe) {
 PixelMapDoubleWide::PixelMapDoubleWide(const MatrixDriver &_matrix) :
     matrix(_matrix)
 {}
-
 // double wide panel arrangement
 // ---------------------------
 // | <- chain 0 | chain 3 -> |

--- a/udp_receiver/main.cpp
+++ b/udp_receiver/main.cpp
@@ -109,14 +109,14 @@ int main(int argc, char **argv) {
 
     // configure rgb matrix panel driver
     MatrixDriver::initGpio(MatrixDriver::gpio_rpi3);
-    matrix = MatrixDriver::createInstance(PWM_BITS, MatrixDriver::HUB75AB, MatrixDriver::Z08AB, MatrixDriver::MIRRORH);
+    matrix = MatrixDriver::createInstance(PWM_BITS, MatrixDriver::HUB75AB, MatrixDriver::Z08AB, MatrixDriver::MIRRORV);
     createPwmLutLinear(PWM_BITS, brightness, matrix->getPwmMapping());
     log("instantiated matrix driver");
     log("matrix canvas is %d x %d", matrix->getWidth(), matrix->getHeight());
 
     // set panel remapping
-  //  PixelMapDoubleWide pixMap(*matrix);
-   // matrix->setPixelMapping(&pixMap);
+    // PixelMapDoubleWide pixMap(*matrix);
+    // matrix->setPixelMapping(&pixMap);
     log("matrix canvas remapped as %d x %d", matrix->getCanvasWidth(), matrix->getCanvasHeight());
 
     // initialize packet buffer
@@ -269,8 +269,8 @@ long microtime() {
 void displayAddress(uint32_t addr) {
     // display ethernet address
     matrix->clearFrame();
-  //  auto x = matrix->getWidth() - 90;
-   auto x = 0;
+    auto x = matrix->getWidth() - 90;
+    //auto x = 0;
     for(int i = 0; i < 4; i++) {
         auto octet = (addr >> ((3u - i) * 8u)) & 0xffu;
         unsigned pow = 100;


### PR DESCRIPTION
Hi Robert.
I found a strange bug in Interleaving code for Z32ABC.
I have to disable the calculations in void Interleavers::dimZ32ABC(unsigned &width, unsigned &height) to make it work.

So Z32ABC only works when matrix dimensions have double the width and half the height.

But Z08AB work as it is without any changes.

I have attempted to add transformers to the lib. Maybe you would like to improve the code.
Also there's a problem with this.

Work's well with Z32ABC (after the mentioned above edit)
But with Z08AB it does mirror the text properly on x but there is offset visible in y. I couldn't figure out why.